### PR TITLE
FIX setup.py to be installable via pip git+...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,34 @@
+from distutils.command.build import build
+from setuptools.command.install import install
 from distutils.core import setup, Extension
-import distutils.command.build
-import numpy as np
-from subprocess import call
 
 
-
+class CustomInstall(install):
+	def run(self):
+		self.run_command('build_ext')
+		build.run(self)
+		self.do_egg_install()
 
 include_dirs = ['${CMAKE_SOURCE_DIR}/include', './include']
 extra_compile_args = ['-O2', '-std=c++11']
-#extra_compile_args = ['-g', '-std=c++11', '-O0']
+# extra_compile_args = ['-g', '-std=c++11', '-O0']
 
 
-
-extensions = [	Extension(
-					name = '_regression',
-					sources=['pyrfr/regression.i'],
-					include_dirs = include_dirs,
-					swig_opts=['-c++'] + ['-I{}'.format(s) for s in include_dirs],
-					extra_compile_args = extra_compile_args
-				),
-				Extension(
-					name = '_util',
-					sources=['pyrfr/util.i'],
-					include_dirs = include_dirs,
-					swig_opts=['-c++'] + ['-I{}'.format(s) for s in include_dirs],
-					extra_compile_args = extra_compile_args
-				)
+extensions = [Extension(
+						name='_regression',
+						sources=['pyrfr/regression.i'],
+						include_dirs=include_dirs,
+						swig_opts=['-c++'] + ['-I{}'.format(s) for s in include_dirs],
+						extra_compile_args=extra_compile_args
+					),
+					Extension(
+							name='_util',
+							sources=['pyrfr/util.i'],
+							include_dirs=include_dirs,
+							swig_opts=['-c++'] + ['-I{}'.format(s) for s in include_dirs],
+							extra_compile_args=extra_compile_args
+						)
 			]
-
 
 setup(
 	name='pyrfr',
@@ -37,5 +38,6 @@ setup(
 	license='Use as you wish. No guarantees whatsoever.',
 	classifiers=['Development Status :: 3 - Alpha'],
 	packages=['pyrfr'],
-	ext_modules=extensions
+	ext_modules=extensions,
+	cmdclass={'install': CustomInstall}
 )


### PR DESCRIPTION
I finally figured out what needed to be changed to be able to install the random forrest via pip git+... (and also work with virtualenv)

In essence, what I had to do was change the build order because all .py files were copied to the target site-packages folder before the build had happened. Because of this regression.py and utils.py were not copied over. I created the CustomInstall to overwrite that behaviour.