### PR TITLE
Tag support for release

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,11 +2,9 @@
 name: Wheel builder
 
 on:
-  push:
-    branches:
-      - master
-      # Release branches
-      - "[0-9]+.[0-9]+.X"
+  create:
+    tags:
+      - v*
 
 jobs:
   # Build the wheels for Linux

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -2,6 +2,11 @@
 name: Wheel builder
 
 on:
+  push:
+    branches:
+      - master
+      # Release branches
+      - "[0-9]+.[0-9]+.X"
   create:
     tags:
       - v*
@@ -81,8 +86,8 @@ jobs:
     name: Upload Release
     runs-on: ubuntu-latest
     needs: [build_wheels, build_sdist]
-    # The artifacts cannot be uploaded on PRs
-    if: github.event_name != 'pull_request'
+    # Only on a tagged release, push
+    if: startsWith(github.ref, 'refs/tags/v')  && github.event_name != 'pull_request'
 
     steps:
       - name: Checkout pyrfr


### PR DESCRIPTION
Create a release ONLY when we create a tag. This will allow us to create the release artifacts only as needed and not on every push to master.