### PR TITLE
Fix error while uploading the release assets

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -114,16 +114,6 @@ jobs:
           #  run: |
           #    twine upload dist/*
 
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
       - name: Upload Release Asset
         id: upload-release-asset
         env:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -114,16 +114,21 @@ jobs:
           #  run: |
           #    twine upload dist/*
 
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
       - name: Upload Release Asset
         id: upload-release-asset
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python -m pip install --upgrade pip
-          set -x
-          assets=()
-          for asset in ./dist/*/*; do
-            assets+=("-a" "$asset")
-          done
           tag_name="${GITHUB_REF##*/}"
-          hub release create "${assets[@]}" -m "$tag_name" "$tag_name"
+          echo Uploading `(find ./dist -type f -printf "-a %p ")`
+          hub release edit $(find ./dist -type f -printf "-a %p ") -m "" "$tag_name"


### PR DESCRIPTION
Tried [here](https://github.com/franchuterivera/random_forest_run/releases/tag/v0.8.8).

Moves away from create release to edit release to prevent problem with a release already created causing the error:

```
Error creating release: Unprocessable Entity (HTTP 422)
Duplicate value for "tag_name"
Error: Process completed with exit code 1.
```