### PR TITLE
Use Copy Directly for Python Package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif(DOXYGEN_FOUND)
 
 if(PYTHONINTERP_FOUND AND SWIG_FOUND)
 	file(COPY ${PROJECT_SOURCE_DIR}/pyrfr DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-	file(RENAME ${CMAKE_CURRENT_BINARY_DIR}/pyrfr ${CMAKE_CURRENT_BINARY_DIR}/python_package)
+	file(COPY ${PROJECT_SOURCE_DIR}/pyrfr/pyrfr DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/python_package)
 
 	configure_file(${PROJECT_SOURCE_DIR}/pyrfr/setup.py ${CMAKE_CURRENT_BINARY_DIR}/python_package/setup.py)
 	configure_file(${PROJECT_SOURCE_DIR}/pyrfr/pyrfr/__init__.py ${CMAKE_CURRENT_BINARY_DIR}/python_package/pyrfr/__init__.py)


### PR DESCRIPTION
Instead of copying the folder and renaming the folder, it is better to just copy the folder, because if the folder exists (e.g. cmake has already been run, or it is being run again to recompile after a change), it will not fail with "Directory is not empty" for rename, but instead update the contents in the files accordingly. There will be duplication but it's the size is small and it's the build directory so it doesn't really matter. 
